### PR TITLE
Update Trailblazer to Echo for Leagues V

### DIFF
--- a/src/main/java/com/unmoon/ToolRequiredPlugin.java
+++ b/src/main/java/com/unmoon/ToolRequiredPlugin.java
@@ -69,7 +69,7 @@ public class ToolRequiredPlugin extends Plugin
 			item(ItemID.CORRUPTED_AXE),
 			item(ItemID.CRYSTAL_AXE_23862),
 			item(ItemID.INFERNAL_AXE_OR),
-			item(ItemID.TRAILBLAZER_AXE),
+			item(ItemID.ECHO_AXE),
 			item(ItemID.INFERNAL_AXE_UNCHARGED_25371),
 			item(ItemID.DRAGON_AXE_OR),
 			item(ItemID.BRONZE_FELLING_AXE),
@@ -108,7 +108,7 @@ public class ToolRequiredPlugin extends Plugin
 			item(ItemID.CORRUPTED_PICKAXE),
 			item(ItemID.CRYSTAL_PICKAXE_23863),
 			item(ItemID.INFERNAL_PICKAXE_OR),
-			item(ItemID.TRAILBLAZER_PICKAXE),
+			item(ItemID.ECHO_PICKAXE),
 			item(ItemID.INFERNAL_PICKAXE_UNCHARGED_25369),
 			item(ItemID.DRAGON_PICKAXE_OR_25376)
 	);


### PR DESCRIPTION
Resolves #2. Tested and verified in-game.

Extra context: Trailblazer tools (https://oldschool.runescape.wiki/w/Trailblazer_axe) were removed and IDs are no longer valid. Added the new Echo ones (https://oldschool.runescape.wiki/w/Echo_axe) in place.