### PR TITLE
Remove canoe station from chop menu handling

### DIFF
--- a/src/main/java/com/unmoon/ToolRequiredPlugin.java
+++ b/src/main/java/com/unmoon/ToolRequiredPlugin.java
@@ -124,7 +124,7 @@ public class ToolRequiredPlugin extends Plugin
 	);
 	private final Set<String> cutOverrides = Sets.newHashSet("Sulliuscep");
 	private final Set<String> chopOverrides = Sets.newHashSet(
-			"Jungle Bush", "Pineapple plant", "Canoe Station", "Vines", "Tendrils", "Bruma roots",
+			"Jungle Bush", "Pineapple plant", "Vines", "Tendrils", "Bruma roots",
 			"Rotten sapling", "Sapling", "Thick vine", "Thick vines", "Corrupt Phren Roots", "Phren Roots"
 	);
 


### PR DESCRIPTION
This is a blanket change to remove this plugin from interfacing with canoe stations.

It may be preferable to have this behavior be toggled by a plugin configuration option, but to me this seems like the most reasonable default behavior given the latest game update.